### PR TITLE
Added .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tincan-bash.sh text eol=lf

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func wsHandler(w http.ResponseWriter, r *http.Request) {
 
 
 
-// Goroutine for "/receive" endpoint
+// Goroutine for "http/receive" endpoint
 func httpReceiveRoutine(wgQ *sync.WaitGroup, w http.ResponseWriter) {
     // Loop over messages in queue and print to http.ResponseWriter
     for i := 0; i < Messages.length; i++ {
@@ -208,7 +208,7 @@ func httpReceiveRoutine(wgQ *sync.WaitGroup, w http.ResponseWriter) {
 }
 
 
-// Goroutine for "/send" endpoint
+// Goroutine for "http/send" endpoint
 func httpSendRoutine(
             wgQ *sync.WaitGroup, 
             user string, 

--- a/tincan-bash.sh
+++ b/tincan-bash.sh
@@ -23,7 +23,7 @@ if [ $httpWebsocket = "http" ]; then
                 --data-urlencode "user=$name"
         done
     elif [ $sendReceive = "receive" ]; then
-        watch -n 3 curl -v "localhost:8080/http/receive"
+        watch -n 5 curl -v "localhost:8080/http/receive"
     else
         echo "unrecognised input"
     fi

--- a/tincan-bash.sh
+++ b/tincan-bash.sh
@@ -23,7 +23,7 @@ if [ $httpWebsocket = "http" ]; then
                 --data-urlencode "user=$name"
         done
     elif [ $sendReceive = "receive" ]; then
-        watch -n 2 curl -v "localhost:8080/http/receive"
+        watch -n 3 curl -v "localhost:8080/http/receive"
     else
         echo "unrecognised input"
     fi


### PR DESCRIPTION
Added .gitattributes file to prevent conversion of LF line endings (Used almost universally) to CRLF line endings (only used in Windows), which I belive was the cause for docker issues between operating systems: copying a bash script with CRLF characters on Windows into a Linux container on build made it unreadable within the container, hence build issues on Windows but not WSL2 which maintains LF line endings.

Other changes were minor comment fixes in main.go and minor changes to bash script in order to commit the script file and have the .gitattributes file take affect (only affects file if it is involved in a commit).